### PR TITLE
update src/webauth/index.js: set clearSession ephemeral default true

### DIFF
--- a/src/webauth/index.js
+++ b/src/webauth/index.js
@@ -135,6 +135,6 @@ export default class WebAuth {
     options.returnTo = callbackUri(domain);
     options.federated = options.federated || false;
     const logoutUrl = client.logoutUrl(options);
-    return agent.show(logoutUrl, false, true);
+    return agent.show(logoutUrl, true, true);
   }
 }


### PR DESCRIPTION
### Changes

Sets `ephemeralSession` argument to default as `true` in the webauth `clearSession` method, allowing apps that use `react-native-auth0` to use the mobile browser auth0 web view to `/logout` without being prompted by the "allow this app to share..." permissions dialog.

### References

See [issue ticket No. 333 on the source repo](https://github.com/auth0/react-native-auth0/issues/333)  for more details.